### PR TITLE
Rename endpoints to singular form

### DIFF
--- a/nginx/sites-enabled/default
+++ b/nginx/sites-enabled/default
@@ -7,12 +7,12 @@ server {
 	root /var/www/html;
 
 
-    location /api/blocks/ {
+    location /api/block/ {
 		proxy_pass http://workflow-block-service:8080/;
 		proxy_set_header Host $host:$server_port;
 	}
 
-	location /api/forms/ {
+	location /api/form/ {
 		proxy_pass http://forms-editor-service:8080/;
 		proxy_set_header Host $host:$server_port;
 	}


### PR DESCRIPTION
It felt more natural for me to have endpoints in singular form. Should research REST conventions before merging.